### PR TITLE
Fixed flaky tests using tempfile crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,6 +1445,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
+ "tempfile",
  "tokio",
 ]
 
@@ -1826,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ clap = { version = "4.5.20", features = ["derive"] }
 log = "0.4"
 simplelog = "^0.12.0"
 colored = "2"
+tempfile = "3.14.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,24 +279,25 @@ fn save_credentials(credentials: &Credentials, config_path: &std::path::Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     /// Set up a temporary directory as `HOME` to test whether `get_config_path()`
     /// returns the accurate path
     #[test]
     fn test_get_config_path() {
-        let temp_home = std::env::temp_dir();
-        std::env::set_var("HOME", &temp_home);
+        let temp_home = tempdir().expect("Failed to create temp directory");
+        env::set_var("HOME", &temp_home.path());
 
         let config_path = get_config_path(CONFIG_DIR, CONFIG_FILE);
 
-        let expected_path = temp_home.join(CONFIG_DIR).join(CONFIG_FILE);
+        let expected_path = temp_home.path().join(CONFIG_DIR).join(CONFIG_FILE);
         assert_eq!(expected_path, config_path);
     }
 
     #[test]
     fn test_save_credentials() {
-        let temp_dir = env::temp_dir();
-        let config_path = temp_dir.join(CONFIG_FILE);
+        let temp_dir = tempdir().expect("Failed to create temp directory");
+        let config_path = temp_dir.path().join(CONFIG_FILE);
 
         let credentials = Credentials {
             username: "testuser".to_string(),
@@ -318,8 +319,8 @@ mod tests {
     /// can read from the file and return the accurate `username` and `password`
     #[test]
     fn test_load_credentials_with_valid_file() {
-        let temp_dir = std::env::temp_dir();
-        let config_file_path = temp_dir.join(CONFIG_FILE);
+        let temp_dir = tempdir().expect("Failed to create temp directory");
+        let config_file_path = temp_dir.path().join(CONFIG_FILE);
 
         let credentials = Credentials {
             username: "testuser".to_string(),


### PR DESCRIPTION
From [std::env::temp_dir](https://doc.rust-lang.org/std/env/fn.temp_dir.html)
> "The temporary directory may be shared among users, or between processes with different privileges; ..."

Test was flaky since multiple tests run async on the same config.json. 

Fixed using tempfile crate.