### PR TITLE
Fix: Killing a process in windows prints command output after exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,13 +10,15 @@ use log::{error, info, warn};
 use notify_rust::Notification;
 use serde::{Deserialize, Serialize};
 use simplelog::*;
+use std::env;
 #[cfg(target_os = "linux")]
 use std::io;
 #[cfg(target_os = "linux")]
 use std::io::Write;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
-use std::{env, process::Stdio};
+#[cfg(target_os = "windows")]
+use std::process::Stdio;
 use std::{process::Command, thread, time};
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1ff8dd32-5778-4ff0-a74c-47c9c2be1344)

After:
![image](https://github.com/user-attachments/assets/378e6ecd-e625-40a0-b02d-cf0e6c58cd9f)
