### PR TITLE
Testing: `main.rs`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,3 +42,31 @@ jobs:
 
     - name: Run tests
       run: cargo test --verbose
+
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install dependencies on Ubuntu
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Generate coverage report
+        run: cargo tarpaulin --verbose --workspace --out Xml
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: cobertura.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ It periodically checks for open exam registrations and automatically registers y
   <a href="https://github.com/dhruvan2006/tuenroll/actions">
     <img src="https://img.shields.io/github/actions/workflow/status/dhruvan2006/tuenroll/rust.yml?branch=main&label=Build&logo=github&logoColor=white&color=blue" alt="Build Status" />
   </a>
+  <a href="https://codecov.io/gh/dhruvan2006/tuenroll"> 
+    <img src="https://codecov.io/gh/dhruvan2006/tuenroll/graph/badge.svg?token=NE7S0F73RL"/> 
+  </a>
   <a href="https://opensource.org/licenses/MIT">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License" />
   </a>

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,6 +9,7 @@ use std::error::Error;
 const AUTH_URL: &str = "https://osi-auth-server-prd2.osiris-link.nl/oauth/authorize?response_type=code&client_id=osiris-authorization-server-tudprd&redirect_uri=https://my.tudelft.nl";
 const TOKEN_URL: &str = "https://my.tudelft.nl/student/osiris/token";
 
+pub const BASE_URL: &str = "https://my.tudelft.nl";
 pub const REGISTERED_COURSE_URL: &str = "https://my.tudelft.nl/student/osiris/student/inschrijvingen/cursussen?toon_historie=N&limit=25";
 pub const TEST_COURSE_URL: &str =
     "https://my.tudelft.nl/student/osiris/student/cursussen_voor_toetsinschrijving/";
@@ -469,21 +470,21 @@ mod tests {
         _mock_final_destination.assert();
     }
 
-    /// Tests a real OAuth flow by calling the live `/oauth/authorize` endpoint.
-    /// Verifies that `initiate_authorization` correctly follows a live 302 redirect and ensures that the response body contains the expected form data and `AuthState` parameter.
-    #[tokio::test]
-    async fn test_initiate_authorization_live() {
-        let api = Api::new();
-        let response = api.initiate_authorization(AUTH_URL).await;
-
-        assert!(response.is_ok());
-        // Url should be of the form https://login.tudelft.nl/sso/module.php/core/loginuserpass.php?AuthState=<auth_state>
-        let (url, body) = response.unwrap();
-        assert!(url
-            .contains("https://login.tudelft.nl/sso/module.php/core/loginuserpass.php?AuthState="));
-        assert!(body.contains("<form"));
-        assert!(body.contains("AuthState"));
-    }
+    // /// Tests a real OAuth flow by calling the live `/oauth/authorize` endpoint.
+    // /// Verifies that `initiate_authorization` correctly follows a live 302 redirect and ensures that the response body contains the expected form data and `AuthState` parameter.
+    // #[tokio::test]
+    // async fn test_initiate_authorization_live() {
+    //     let api = Api::new();
+    //     let response = api.initiate_authorization(AUTH_URL).await;
+    //
+    //     assert!(response.is_ok());
+    //     // Url should be of the form https://login.tudelft.nl/sso/module.php/core/loginuserpass.php?AuthState=<auth_state>
+    //     let (url, body) = response.unwrap();
+    //     assert!(url
+    //         .contains("https://login.tudelft.nl/sso/module.php/core/loginuserpass.php?AuthState="));
+    //     assert!(body.contains("<form"));
+    //     assert!(body.contains("AuthState"));
+    // }
 
     #[test]
     fn test_get_auth_state() {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,0 +1,636 @@
+use crate::api::ApiTrait;
+use crate::creds::{CredentialManager, CredentialManagerTrait, Credentials};
+use crate::{api, get_config_path, store_last_check_time};
+use colored::Colorize;
+use log::{error, info};
+use std::{thread, time};
+
+pub struct Controller<T, F, G> {
+    api: T,
+    exit_fn: F,
+    manager: G,
+    is_loop: bool,
+    is_boot: bool,
+}
+
+impl<T: ApiTrait + Sync + 'static, F: FnOnce(i32) + Clone + Send, G: CredentialManagerTrait<T>>
+    Controller<T, F, G>
+{
+    pub fn new(api: T, exit_fn: F, manager: G, is_loop: bool, is_boot: bool) -> Self {
+        Controller {
+            api,
+            exit_fn,
+            manager,
+            is_loop,
+            is_boot,
+        }
+    }
+
+    pub async fn run_loop<H: FnMut(&str)>(
+        &self,
+        show_notif_fn: &mut H,
+        interval_secs: u32,
+        sleep_interval_secs: u32,
+    ) {
+        let _ = self.run_auto_sign_up(&mut *show_notif_fn).await;
+
+        let mut start_time = std::time::SystemTime::now();
+        loop {
+            info!("Checking whether time interval is completed");
+            if std::time::SystemTime::now()
+                .duration_since(start_time)
+                .unwrap()
+                .as_secs()
+                >= interval_secs as u64
+            {
+                info!("Running auto sign up");
+                match self.run_auto_sign_up(&mut *show_notif_fn).await {
+                    Ok(_) => info!("Auto sign-up successful."),
+                    Err(err) if err == "Invalid credentials" => {
+                        error!("Invalid credentials detected.");
+                        show_notif_fn("Your credentials are invalid. Run tuenroll start again");
+                        break; // !!! Stops the background process !!!
+                    }
+                    Err(_) => {
+                        error!("Failure: A network error occurred");
+                    }
+                }
+                start_time = std::time::SystemTime::now();
+            }
+            tokio::time::sleep(time::Duration::from_secs(sleep_interval_secs as u64)).await;
+        }
+    }
+
+    pub async fn get_credentials(&self) -> Credentials {
+        let credentials;
+
+        loop {
+            let request = self.manager.get_valid_credentials(
+                Credentials::load_from_keyring,
+                CredentialManager::<T>::prompt_for_credentials,
+                !self.is_boot,
+            );
+            if let Some(data) = self.handle_request(request.await) {
+                credentials = data;
+                if !self.is_boot {
+                    println!("{}", "Credentials validated successfully!".green().bold());
+                }
+                break;
+            }
+        }
+
+        credentials
+    }
+
+    /// Runs the auto signup fully once
+    /// Gets the credentials, the access token
+    /// Automatically signs up for all the tests
+    /// Prints the result of execution
+    pub async fn run_auto_sign_up<H: FnMut(&str)>(
+        &self,
+        mut show_notif_fn: H,
+    ) -> Result<(), String> {
+        // Creds don't exist
+        let credentials = self
+            .manager
+            .get_valid_credentials(
+                Credentials::load_from_keyring,
+                Credentials::default,
+                !self.is_loop,
+            )
+            .await;
+        if credentials.is_err() {
+            return Err("Invalid credentials".to_string());
+        }
+        let credentials = credentials.unwrap();
+
+        // Check if creds are valid
+        if !self
+            .manager
+            .validate_stored_token(&credentials, api::REGISTERED_COURSE_URL)
+            .await
+            .map_err(|e| e.to_string())?
+        {
+            return Err("Invalid credentials".to_string());
+        }
+
+        let access_token = credentials
+            .access_token
+            .clone()
+            .expect("Access token should be present");
+        let registration_result;
+        loop {
+            let request = self.api.register_for_tests(
+                &access_token,
+                api::REGISTERED_COURSE_URL,
+                api::TEST_COURSE_URL,
+                api::TEST_REGISTRATION_URL,
+            );
+            if let Some(data) = self.handle_request(request.await) {
+                registration_result = data;
+                break;
+            }
+        }
+
+        let course_korte_naam_result: Vec<String> = registration_result
+            .iter()
+            .map(|test_list| test_list.cursus_korte_naam.clone())
+            .collect();
+        if course_korte_naam_result.is_empty() {
+            info!("No exams were enrolled for.");
+        } else {
+            info!(
+                "Successfully enrolled for the following exams: {:?}",
+                course_korte_naam_result
+            );
+            // Send desktop notification
+            for course_name in course_korte_naam_result {
+                show_notif_fn(&format!(
+                    "You have been successfully registered for the exam: {}",
+                    course_name
+                ));
+            }
+        }
+
+        // Store the last check time
+        store_last_check_time(get_config_path);
+
+        Ok(())
+    }
+
+    fn handle_request<R, E: ToString>(&self, request: Result<R, E>) -> Option<R> {
+        match request {
+            Ok(data) => Some(data),
+            Err(e) => {
+                // Logs the error and wait 5 seconds before continuing
+                if !self.is_boot {
+                    eprintln!("{}", e.to_string().red().bold());
+                }
+                error!("{}", e.to_string());
+
+                if e.to_string() != "Invalid credentials" {
+                    if !self.is_loop {
+                        self.exit_fn.clone()(0); // Exit if `run` and no internet connection
+                    }
+                    thread::sleep(time::Duration::from_secs(5));
+                }
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    /// Tests for `get_credentials()`
+    mod get_credentials_test {
+        use crate::api::MockApiTrait;
+        use crate::controller::Controller;
+        use crate::creds::{Credentials, MockCredentialManagerTrait};
+
+        /// Test when credential retrieval first fails then success
+        #[tokio::test]
+        async fn test_get_credentials_success() {
+            let mock_api = MockApiTrait::new();
+            let mut mock_manager = MockCredentialManagerTrait::default();
+
+            // First two attempts fail, then succeed on the third.
+            let mock_credentials = Credentials {
+                username: Some("test_username".to_string()),
+                password: Some("test_password".to_string()),
+                access_token: Some("valid_token".to_string()),
+            };
+            let expected_credentials = mock_credentials.clone();
+
+            mock_manager
+                .expect_get_valid_credentials()
+                .returning(|_, _, _| Err("Invalid credentials".into()))
+                .times(2); // simulate two failures
+            mock_manager
+                .expect_get_valid_credentials()
+                .returning(move |_, _, _| Ok(mock_credentials.clone()))
+                .times(1); // simulate one success
+
+            let controller = Controller {
+                api: mock_api,
+                exit_fn: |_| {},
+                manager: mock_manager,
+                is_loop: true,
+                is_boot: false,
+            };
+            let result = controller.get_credentials().await;
+
+            assert_eq!(expected_credentials, result);
+        }
+    }
+
+    /// Tests for `handle_request()`
+    mod handle_request_tests {
+        use crate::api::MockApiTrait;
+        use crate::controller::Controller;
+        use crate::creds::MockCredentialManagerTrait;
+        use std::process::exit;
+        use std::sync::mpsc;
+
+        /// Test when request is successful (Ok)
+        #[test]
+        fn test_handle_request_ok() {
+            let request: Result<i32, Box<dyn std::error::Error>> = Ok(42);
+            let controller = Controller {
+                api: MockApiTrait::new(),
+                exit_fn: |code: i32| exit(code),
+                manager: MockCredentialManagerTrait::default(),
+                is_loop: false,
+                is_boot: false,
+            };
+            let response = controller.handle_request(request);
+
+            assert_eq!(response, Some(42)); // should just return the data
+        }
+
+        /// Test for a request with `Invalid credentials` Error
+        #[test]
+        fn test_handle_request_invalid_credentials() {
+            let request: Result<i32, Box<dyn std::error::Error>> =
+                Err("Invalid credentials".into());
+            let controller = Controller {
+                api: MockApiTrait::new(),
+                exit_fn: |code: i32| exit(code),
+                manager: MockCredentialManagerTrait::default(),
+                is_loop: false,
+                is_boot: false,
+            };
+            let response = controller.handle_request(request);
+
+            assert_eq!(response, None); // Should return None, without exiting or sleeping
+        }
+
+        /// Test request with `Network Error` when called on `Run` (is_loop = false, boot = false)
+        #[test]
+        fn test_handle_request_run_case() {
+            let request: Result<i32, Box<dyn std::error::Error>> = Err("Network error".into());
+            let (sender, receiver) = mpsc::channel();
+            let mock_exit_fn = move |code: i32| sender.send(code).unwrap();
+
+            let controller = Controller {
+                api: MockApiTrait::new(),
+                exit_fn: mock_exit_fn,
+                manager: MockCredentialManagerTrait::default(),
+                is_loop: false,
+                is_boot: false,
+            };
+            let response = controller.handle_request(request);
+            assert_eq!(response, None); // Should return None
+
+            // Ensure exit_fn is called with code 0 for 'Network error'
+            let exit_code = receiver.recv().unwrap();
+            assert_eq!(exit_code, 0); // Exit code should be 0
+        }
+
+        /// Test request with `Network Error` when called on `Start` (is_loop = true, boot = false)
+        #[test]
+        fn test_handle_request_start_case() {
+            let request: Result<i32, Box<dyn std::error::Error>> = Err("Network error".into());
+            let (sender, receiver) = mpsc::channel();
+            let mock_exit_fn = move |code: i32| sender.send(code).unwrap();
+
+            let controller = Controller {
+                api: MockApiTrait::new(),
+                exit_fn: mock_exit_fn,
+                manager: MockCredentialManagerTrait::default(),
+                is_loop: true,
+                is_boot: false,
+            };
+            let response = controller.handle_request(request);
+            assert_eq!(response, None); // Should return None (error occurs)
+
+            // Ensure exit_fn is not called since we're looping
+            let exit_result = receiver.recv_timeout(std::time::Duration::from_secs(1));
+            assert!(exit_result.is_err());
+        }
+
+        /// Test request with `Network Error` when called on `Boot` (is_loop = true, boot = true)
+        #[test]
+        fn test_handle_request_boot_case() {
+            let request: Result<i32, Box<dyn std::error::Error>> = Err("Network error".into());
+            let (sender, receiver) = mpsc::channel();
+            let mock_exit_fn = move |code: i32| sender.send(code).unwrap();
+
+            let controller = Controller {
+                api: MockApiTrait::new(),
+                exit_fn: mock_exit_fn,
+                manager: MockCredentialManagerTrait::default(),
+                is_loop: true,
+                is_boot: true,
+            };
+            let response = controller.handle_request(request);
+            assert_eq!(response, None); // Should return None
+
+            // Ensure exit_fn is not called due to looping
+            let exit_result = receiver.recv_timeout(std::time::Duration::from_secs(1));
+            assert!(exit_result.is_err()); // Should time out without calling exit_fn
+        }
+    }
+
+    /// Tests for `run_auto_sign_up()`
+    mod run_auto_sign_up_tests {
+        use crate::api::ApiTrait;
+        use crate::controller::Controller;
+        use crate::creds::{CredentialManagerTrait, Credentials};
+        use crate::models::TestList;
+        use async_trait::async_trait;
+        use mockall::mock;
+        use mockall::predicate::*;
+        use std::error::Error;
+
+        // Mock implementations for testing
+        mock! {
+            Api {}
+            #[async_trait]
+            impl ApiTrait for Api {
+                async fn is_user_authenticated(
+                    &self,
+                    access_token: &str,
+                    url: &str,
+                ) -> Result<bool, Box<dyn Error>>;
+
+                async fn get_access_token(
+                    &self,
+                    username: &str,
+                    password: &str,
+                ) -> Result<String, Box<dyn Error>>;
+
+                async fn register_for_tests(
+                    &self,
+                    access_token: &str,
+                    registered_course_url: &str,
+                    test_course_url: &str,
+                    test_registration_url: &str,
+                ) -> Result<Vec<TestList>, Box<dyn Error>>;
+            }
+        }
+
+        impl Clone for MockApi {
+            fn clone(&self) -> Self {
+                MockApi::new()
+            }
+        }
+
+        mock! {
+            CredentialManager {}
+            #[async_trait]
+            impl CredentialManagerTrait<MockApi> for CredentialManager {
+                // fn new(api: MockApi, service_name: String) -> Self;
+                // fn delete_credentials(&self);
+                // fn has_credentials(&self) -> bool;
+                // fn prompt_for_credentials() -> Credentials;
+
+                async fn get_valid_credentials<F, G>(
+                    &self,
+                    loader: F,
+                    prompt_fn: G,
+                    show_spinner: bool,
+                ) -> Result<Credentials, Box<dyn Error>>
+                where
+                    F: Fn(&str) -> Result<Credentials, Box<dyn Error>> + Send + Sync + 'static,
+                    G: Fn() -> Credentials + Send + Sync + 'static;
+
+                async fn validate_stored_token(
+                    &self,
+                    credentials: &Credentials,
+                    url: &str,
+                ) -> Result<bool, Box<dyn Error>>;
+            }
+        }
+
+        /// Test successful run with multiple open exams
+        #[tokio::test]
+        async fn test_run_auto_sign_up_successful_multiple_exams() {
+            let mut mock_api = MockApi::new();
+            let mut mock_manager = MockCredentialManager::default();
+
+            // Has valid access_token
+            let mock_credentials = Credentials {
+                access_token: Some("valid_token".to_string()),
+                ..Default::default()
+            };
+            mock_manager
+                .expect_get_valid_credentials()
+                .return_once(move |_, _, _| Ok(mock_credentials.clone()));
+
+            mock_manager
+                .expect_validate_stored_token()
+                .return_once(|_, _| Ok(true));
+
+            // Returns a list of courses to sign up for
+            let test_list = vec![
+                TestList {
+                    cursus_korte_naam: "MATH101".to_string(),
+                    ..Default::default()
+                },
+                TestList {
+                    cursus_korte_naam: "CS102".to_string(),
+                    ..Default::default()
+                },
+            ];
+            mock_api
+                .expect_register_for_tests()
+                .return_once(move |_, _, _, _| Ok(test_list.clone()));
+
+            // Dummy exit function
+            let exit_fn = |_: i32| {};
+
+            // Create a spy for the notif_fn
+            let mut notif_fn_called_with = Vec::new();
+            let notif_fn = |course_name: &str| {
+                notif_fn_called_with.push(course_name.to_string());
+            };
+
+            let controller = Controller {
+                api: mock_api,
+                exit_fn,
+                manager: mock_manager,
+                is_loop: true,
+                is_boot: true,
+            };
+            let result = controller.run_auto_sign_up(notif_fn).await;
+
+            // Result needs to be `Ok`
+            assert!(result.is_ok());
+            // Notification called with appropriate course names
+            assert!(notif_fn_called_with[0].contains(&"MATH101".to_string()));
+            assert!(notif_fn_called_with[1].contains(&"CS102".to_string()));
+        }
+
+        /// Test successful run with no open exams
+        #[tokio::test]
+        async fn test_run_auto_sign_up_successful_no_exams() {
+            let mut mock_api = MockApi::new();
+            let mut mock_manager = MockCredentialManager::default();
+
+            // Has valid access_token
+            let mock_credentials = Credentials {
+                access_token: Some("valid_token".to_string()),
+                ..Default::default()
+            };
+            mock_manager
+                .expect_get_valid_credentials()
+                .return_once(move |_, _, _| Ok(mock_credentials.clone()));
+
+            mock_manager
+                .expect_validate_stored_token()
+                .return_once(|_, _| Ok(true));
+
+            // Returns empty list of couses
+            let empty_test_list = vec![];
+            mock_api
+                .expect_register_for_tests()
+                .return_once(move |_, _, _, _| Ok(empty_test_list.clone()));
+
+            // Dummy exit function
+            let exit_fn = |_: i32| {};
+
+            // Create a spy for the notif_fn
+            let mut notif_fn_called_with = Vec::new();
+            let notif_fn = |course_name: &str| {
+                notif_fn_called_with.push(course_name.to_string());
+            };
+
+            let controller = Controller {
+                api: mock_api,
+                exit_fn,
+                manager: mock_manager,
+                is_loop: true,
+                is_boot: true,
+            };
+            let result = controller.run_auto_sign_up(notif_fn).await;
+
+            // Result needs to be `Ok`
+            assert!(result.is_ok());
+            // Notification not called
+            assert!(notif_fn_called_with.is_empty());
+        }
+
+        /// Test when credentials are invalid
+        #[tokio::test]
+        async fn test_run_auto_sign_up_invalid_credentials() {
+            let mock_api = MockApi::new();
+            let mut mock_manager = MockCredentialManager::default();
+
+            // `get_valid_credentials()` returns `Err`
+            mock_manager
+                .expect_get_valid_credentials()
+                .return_once(move |_, _, _| Err("".into()));
+
+            let controller = Controller {
+                api: mock_api,
+                exit_fn: |_| {},
+                manager: mock_manager,
+                is_loop: true,
+                is_boot: true,
+            };
+            let result = controller.run_auto_sign_up(|_| {}).await;
+
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err(), "Invalid credentials");
+        }
+    }
+
+    /// Tests for `run_loop()`
+    mod run_loop_tests {
+        use crate::api::MockApiTrait;
+        use crate::controller::Controller;
+        use crate::creds::{Credentials, MockCredentialManagerTrait};
+        use crate::models::TestList;
+        use std::time::Duration;
+
+        /// Tests that `run_loop()` successfully calls `run_auto_sign_up()` at intervals by asserting notifications
+        ///
+        /// We set run_loop with settings interval_secs = 2 and sleep_interval_secs = 1
+        /// The timeout by tokio stops the loop after 3.5 seconds, this results in `run_auto_sign_up()`
+        /// being called a total of 3 times (2 on startup and 1 after one sleep iteration)
+        #[tokio::test]
+        async fn test_run_loop_success() {
+            let mut api_mock = MockApiTrait::new();
+            let mut manager_mock = MockCredentialManagerTrait::default();
+            let mut notifications = Vec::new();
+
+            manager_mock
+                .expect_get_valid_credentials()
+                .returning(|_, _, _| {
+                    Ok(Credentials {
+                        access_token: Some("token".to_string()),
+                        ..Default::default()
+                    })
+                });
+
+            manager_mock
+                .expect_validate_stored_token()
+                .returning(|_, _| Ok(true));
+
+            api_mock
+                .expect_register_for_tests()
+                .returning(|_, _, _, _| {
+                    Ok(vec![TestList {
+                        cursus_korte_naam: "Test Exam".to_string(),
+                        ..Default::default()
+                    }])
+                });
+
+            let controller = Controller::new(api_mock, |_| {}, manager_mock, true, true);
+
+            let timeout_duration = Duration::from_millis(3500);
+
+            let _ = tokio::time::timeout(timeout_duration, async {
+                controller
+                    .run_loop(&mut |msg: &str| notifications.push(msg.to_string()), 2, 1)
+                    .await;
+            })
+            .await;
+
+            assert_eq!(notifications.len(), 2);
+            assert!(notifications.iter().all(|x| x.contains("Test Exam")));
+        }
+
+        /// Tests that `run_loop()` exits when invalid credentials are detected and shows notification
+        /// to the user to run `tuenroll start`
+        #[tokio::test]
+        async fn test_run_loop_invalid_credentials() {
+            let mut api_mock = MockApiTrait::new();
+            let mut manager_mock = MockCredentialManagerTrait::default();
+            let mut notifications = Vec::new();
+
+            manager_mock
+                .expect_get_valid_credentials()
+                .returning(|_, _, _| {
+                    Ok(Credentials {
+                        access_token: Some("token".to_string()),
+                        ..Default::default()
+                    })
+                });
+
+            manager_mock
+                .expect_validate_stored_token()
+                .returning(|_, _| Ok(false));
+
+            api_mock
+                .expect_register_for_tests()
+                .returning(|_, _, _, _| Err("Invalid credentials".into()));
+
+            let controller = Controller::new(api_mock, |_| {}, manager_mock, true, true);
+
+            let timeout_duration = Duration::from_millis(3500);
+
+            let _ = tokio::time::timeout(timeout_duration, async {
+                controller
+                    .run_loop(&mut |msg: &str| notifications.push(msg.to_string()), 2, 1)
+                    .await;
+            })
+            .await;
+
+            assert!(notifications[0]
+                .contains(&"Your credentials are invalid. Run tuenroll start again".to_string()));
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
 mod api;
+mod controller;
 mod creds;
 mod models;
-use crate::api::ApiTrait;
+
+use crate::controller::Controller;
 use ::time::UtcOffset;
 use api::Api;
 use clap::{Parser, Subcommand};
 use colored::*;
-use creds::{CredentialManager, Credentials};
+use creds::CredentialManager;
 use log::{error, info, warn};
 use notify_rust::Notification;
 use serde::{Deserialize, Serialize};
@@ -18,10 +20,11 @@ use std::io;
 use std::io::Write;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
+use std::path::PathBuf;
 use std::process::exit;
+use std::process::Command;
 #[cfg(target_os = "windows")]
 use std::process::Stdio;
-use std::{process::Command, thread, time};
 
 #[derive(Serialize, Deserialize)]
 struct Pid {
@@ -73,7 +76,7 @@ const LOG_FILE: &str = "tuenroll.log";
 #[tokio::main]
 async fn main() {
     // Check if it's the first setup
-    if is_first_setup() {
+    if is_first_setup(dirs::home_dir) {
         display_logo();
 
         println!("{}", "Welcome to TUEnroll CLI!".bright_cyan());
@@ -89,11 +92,17 @@ async fn main() {
 
     let manager = CredentialManager::new(Api::new(), APP_NAME.to_string());
 
+    // Wrap `exit()` function with a function returning `?` instead of experimental `!`
+    let exit_fn = |code: i32| {
+        exit(code);
+    };
+
     match &cli.command {
         Commands::Run => {
             info!("Starting the 'Run' command execution.");
-            let _ = get_credentials(&manager, false, false).await;
-            match run_auto_sign_up(false, &manager, false).await {
+            let run_controller = Controller::new(Api::new(), exit_fn, manager, false, false);
+            let _ = run_controller.get_credentials().await;
+            match run_controller.run_auto_sign_up(show_notification).await {
                 Ok(()) => println!("{}", "Success: Exam check ran.".green().bold()),
                 Err(err) if err == "Invalid credentials" => {
                     // Invalid credentials should definitely never happen
@@ -105,12 +114,14 @@ async fn main() {
         Commands::Start { interval, boot } => {
             info!("Starting the 'Start' command execution.");
 
+            let start_controller = Controller::new(Api::new(), exit_fn, manager, true, *boot);
+
             // WARNING: Do not have any print statements or the command and process will stop working detached
             if env::var("DAEMONIZED").err().is_some() {
-                let _ = get_credentials(&manager, true, *boot).await;
+                let _ = start_controller.get_credentials().await;
 
                 // Checks whether a process was running, if not don't run the program
-                if *boot && get_stored_pid().is_none() {
+                if *boot && get_stored_pid(get_config_path).is_none() {
                     info!("Boot is enabled but no process was running. Stopping execution");
                     return;
                 } else if !boot {
@@ -134,7 +145,7 @@ async fn main() {
 
                 let child = command.spawn().unwrap();
 
-                store_pid(Some(child.id()));
+                store_pid(Some(child.id()), get_config_path);
                 //println!("{}", "Success: Service started.".green().bold());
                 info!("Daemon process started with PID: {}", child.id());
                 if !boot {
@@ -143,7 +154,9 @@ async fn main() {
                 return;
             } else {
                 info!("Daemon process enabled: starting loop");
-                run_loop(interval, &manager, *boot).await;
+                start_controller
+                    .run_loop(&mut show_notification, interval * 3600, 3600)
+                    .await;
             }
         }
         Commands::Stop => {
@@ -162,7 +175,8 @@ async fn main() {
         }
         Commands::Status => {
             info!("Fetching the current status.");
-            let process_status = if let Some(Some(pid)) = process_is_running().then(get_stored_pid)
+            let process_status = if let Some(Some(pid)) =
+                process_is_running().then(|| get_stored_pid(get_config_path))
             {
                 format!("Running (PID: {}).", pid).green()
             } else {
@@ -175,12 +189,12 @@ async fn main() {
                 "No credentials saved.".to_string().red()
             };
 
-            let network_status = match check_network_status().await {
-                Ok(status) => status.green(),
-                Err(_) => "Network check failed.".to_string().red(),
+            let network_status = match check_network_status(api::BASE_URL).await {
+                Ok(()) => "Network is up.".green(),
+                Err(_) => "Network is down.".red(),
             };
 
-            let last_check_status = match get_last_check_time() {
+            let last_check_status = match get_last_check_time(get_config_path) {
                 Some(time) => time.green(),
                 None => "No previous checks recorded.".to_string().red(),
             };
@@ -195,7 +209,8 @@ async fn main() {
         Commands::Change => {
             info!("Changing credentials.");
             manager.delete_credentials();
-            let _ = get_credentials(&manager, false, false).await;
+            let change_controller = Controller::new(Api::new(), exit_fn, manager, false, false);
+            let _ = change_controller.get_credentials().await;
         }
         Commands::Delete => {
             info!("Deleting credentials.");
@@ -219,8 +234,8 @@ async fn main() {
     }
 }
 
-fn is_first_setup() -> bool {
-    let config_path = dirs::home_dir()
+fn is_first_setup<F: Fn() -> Option<PathBuf>>(home_dir_fn: F) -> bool {
+    let config_path = home_dir_fn()
         .expect("Unable to find home directory")
         .join(CONFIG_DIR);
 
@@ -260,14 +275,17 @@ fn set_up_logging() {
     // info!("Initialized the logger");
 }
 
-async fn check_network_status() -> Result<String, Box<dyn std::error::Error>> {
-    match reqwest::get("https://my.tudelft.nl/").await {
-        Ok(_) => Ok("Network is up.".to_string()),
-        Err(_) => Ok("Network is down.".to_string()),
+async fn check_network_status(url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let response = reqwest::get(url).await?;
+
+    if response.status().is_server_error() {
+        return Err(format!("Server Error: HTTP {}", response.status()).into());
     }
+
+    Ok(())
 }
 
-fn store_last_check_time() {
+fn store_last_check_time<F: Fn(&str, &str) -> PathBuf>(get_config_path: F) {
     let last_check_time = chrono::Utc::now().to_rfc3339();
     let path = get_config_path(CONFIG_DIR, LAST_CHECK_FILE);
     let data = serde_json::json!({ "last_check": last_check_time });
@@ -278,7 +296,7 @@ fn store_last_check_time() {
     }
 }
 
-fn get_last_check_time() -> Option<String> {
+fn get_last_check_time<F: Fn(&str, &str) -> PathBuf>(get_config_path: F) -> Option<String> {
     let path = get_config_path(CONFIG_DIR, LAST_CHECK_FILE);
 
     if let Ok(content) = std::fs::read_to_string(path) {
@@ -298,7 +316,7 @@ fn get_last_check_time() -> Option<String> {
     None
 }
 
-// Helper function to calculate time difference
+/// Helper function to calculate time difference
 fn time_ago(last_check_time: chrono::DateTime<chrono::FixedOffset>) -> String {
     let now = chrono::Utc::now();
     let duration = now.signed_duration_since(last_check_time.with_timezone(&chrono::Utc));
@@ -336,37 +354,7 @@ fn display_logo() {
     );
 }
 
-async fn run_loop<T: ApiTrait>(interval: &u32, manager: &CredentialManager<T>, is_boot: bool) {
-    let _ = run_auto_sign_up(true, manager, is_boot).await;
-
-    let mut start_time = std::time::SystemTime::now();
-    loop {
-        info!("Checking whether time interval is completed");
-        if std::time::SystemTime::now()
-            .duration_since(start_time)
-            .unwrap()
-            .as_secs()
-            >= (interval * 3600).into()
-        {
-            info!("Running auto sign up");
-            match run_auto_sign_up(true, manager, is_boot).await {
-                Ok(_) => info!("Auto sign-up successful."),
-                Err(err) if err == "Invalid credentials" => {
-                    error!("Invalid credentials detected.");
-                    show_notification("Your credentials are invalid. Run tuenroll start again");
-                    break; // !!! Stops the background process !!!
-                }
-                Err(_) => {
-                    error!("Failure: A network error occurred");
-                }
-            }
-            start_time = std::time::SystemTime::now();
-        }
-        thread::sleep(time::Duration::from_secs(3600));
-    }
-}
-
-fn get_stored_pid() -> Option<u32> {
+fn get_stored_pid<F: Fn(&str, &str) -> PathBuf>(get_config_path: F) -> Option<u32> {
     if let Ok(pid) = std::fs::read_to_string(get_config_path(CONFIG_DIR, PID_FILE)) {
         if let Ok(pid) = serde_json::from_str::<Pid>(&pid) {
             return pid.pid;
@@ -376,7 +364,7 @@ fn get_stored_pid() -> Option<u32> {
 }
 
 fn stop_program() -> Option<u32> {
-    let pid = get_stored_pid();
+    let pid = get_stored_pid(get_config_path);
     pid?;
     let pid = pid.unwrap();
 
@@ -398,12 +386,12 @@ fn stop_program() -> Option<u32> {
     }
 
     info!("Successfully stopped the process with PID: {}", pid);
-    store_pid(None);
+    store_pid(None, get_config_path);
     Some(pid)
 }
 
 fn process_is_running() -> bool {
-    let stored_pid = get_stored_pid();
+    let stored_pid = get_stored_pid(get_config_path);
     if stored_pid.is_none() {
         return false;
     };
@@ -445,114 +433,13 @@ fn process_is_running() -> bool {
                 "Process with PID {} is not running. Cleaning up PID store.",
                 stored_pid
             );
-            store_pid(None);
+            store_pid(None, get_config_path);
             false
         } else {
             info!("Process with PID {} is running.", stored_pid);
             true
         }
     }
-}
-
-async fn get_credentials<T: ApiTrait>(
-    manager: &CredentialManager<T>,
-    is_loop: bool,
-    is_boot: bool,
-) -> Credentials {
-    let credentials;
-
-    loop {
-        let request = manager.get_valid_credentials(
-            Credentials::load_from_keyring,
-            CredentialManager::<T>::prompt_for_credentials,
-            !is_boot,
-        );
-        if let Some(data) = handle_request(is_loop, request.await, is_boot) {
-            credentials = data;
-            if !is_boot {
-                println!("{}", "Credentials validated successfully!".green().bold());
-            }
-            break;
-        }
-    }
-
-    credentials
-}
-
-/// Runs the auto signup fully once
-/// Gets the credentials, the access token
-/// Automatically signs up for all the tests
-/// Prints the result of execution
-async fn run_auto_sign_up<T: ApiTrait>(
-    is_loop: bool,
-    manager: &CredentialManager<T>,
-    is_boot: bool,
-) -> Result<(), String> {
-    // Creds don't exist
-    let credentials = manager
-        .get_valid_credentials(
-            Credentials::load_from_keyring,
-            Credentials::default,
-            !is_loop,
-        )
-        .await;
-    if credentials.is_err() {
-        return Err("Invalid credentials".to_string());
-    }
-    let credentials = credentials.unwrap();
-
-    // Check if creds are valid
-    if !manager
-        .validate_stored_token(&credentials, api::REGISTERED_COURSE_URL)
-        .await
-        .map_err(|e| e.to_string())?
-    {
-        return Err("Invalid credentials".to_string());
-    }
-
-    let access_token = credentials
-        .access_token
-        .clone()
-        .expect("Access token should be present");
-    let registration_result;
-    let api: Box<dyn ApiTrait> = Box::new(Api::new());
-    loop {
-        let request = api.register_for_tests(
-            &access_token,
-            api::REGISTERED_COURSE_URL,
-            api::TEST_COURSE_URL,
-            api::TEST_REGISTRATION_URL,
-        );
-        if let Some(data) = handle_request(is_loop, request.await, is_boot) {
-            registration_result = data;
-            break;
-        }
-    }
-
-    let course_korte_naam_result: Vec<String> = registration_result
-        .iter()
-        .map(|test_list| test_list.cursus_korte_naam.clone())
-        .collect();
-    if course_korte_naam_result.is_empty() {
-        info!("No exams were enrolled for.");
-    } else {
-        info!(
-            "Successfully enrolled for the following exams: {:?}",
-            course_korte_naam_result
-        );
-        // Send desktop notification
-        for course_name in course_korte_naam_result {
-            show_notification(&format!(
-                "You have been successfully registered for the exam: {}",
-                course_name
-            ));
-        }
-    }
-
-    // Store the last check time
-    store_last_check_time();
-
-    Ok(())
 }
 
 fn show_notification(body: &str) {
@@ -567,31 +454,6 @@ fn show_notification(body: &str) {
     }
 }
 
-fn handle_request<R, E: ToString>(
-    is_loop: bool,
-    request: Result<R, E>,
-    is_boot: bool,
-) -> Option<R> {
-    match request {
-        Ok(data) => Some(data),
-        Err(e) => {
-            // Logs the error and wait 5 seconds before continuing
-            if !is_boot {
-                eprintln!("{}", e.to_string().red().bold());
-            }
-            error!("{}", e.to_string());
-
-            if e.to_string() != "Invalid credentials" {
-                if !is_loop {
-                    exit(0); // Exit if `run` and no internet connection
-                }
-                thread::sleep(time::Duration::from_secs(5));
-            }
-            None
-        }
-    }
-}
-
 /// Returns the path to the user's home directory, combined with a hidden directory `config_dir`
 /// and the config file `config_file`
 fn get_config_path(config_dir: &str, config_file: &str) -> std::path::PathBuf {
@@ -603,7 +465,7 @@ fn get_config_path(config_dir: &str, config_file: &str) -> std::path::PathBuf {
     }
 }
 
-fn store_pid(process_id: Option<u32>) {
+fn store_pid<F: Fn(&str, &str) -> PathBuf>(process_id: Option<u32>, get_config_path: F) {
     let pid = Pid { pid: process_id };
     let pid = serde_json::to_string(&pid).expect("Failed to serialise PID");
     let _ = std::fs::write(get_config_path(CONFIG_DIR, PID_FILE), pid);
@@ -675,4 +537,202 @@ fn run_on_boot_linux(interval: &u32) -> Result<(), Box<dyn std::error::Error>> {
     file.write_all(desktop_entry.as_bytes())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Duration, Utc};
+    use std::fs;
+
+    #[test]
+    fn test_get_config_path() {
+        let home = tempfile::TempDir::new().unwrap();
+        // Set HOME variable for Linux/macOS, and USERPROFILE for Windows
+        if cfg!(target_os = "windows") {
+            env::set_var("USERPROFILE", home.path());
+        } else {
+            env::set_var("HOME", home.path());
+        }
+
+        let path = get_config_path(CONFIG_DIR, PID_FILE);
+
+        // Using `MAIN_SEPARATOR` because of differences between Linux/macOS and Windows
+        let expected_subpath = ".tuenroll".to_string()
+            + std::path::MAIN_SEPARATOR.to_string().as_str()
+            + "process.json";
+        assert!(path.to_str().unwrap().contains(&expected_subpath));
+    }
+
+    #[test]
+    fn test_is_first_setup() {
+        let home = tempfile::TempDir::new().unwrap();
+
+        let mock_home_dir_fn = || Some(home.path().to_path_buf());
+
+        assert!(is_first_setup(mock_home_dir_fn)); // `.tuenroll` not yet created
+
+        let config_path = home.path().to_owned().join(CONFIG_DIR);
+        fs::create_dir_all(&config_path).unwrap();
+
+        assert!(!is_first_setup(mock_home_dir_fn)); // `.tuenroll` now exists
+    }
+
+    /// Tests related to `Status` command:
+    /// 1. `check_network_status()`
+    /// 2. `store_last_check_time()`
+    /// 3. `get_last_check_time()`
+    /// 4. `time_ago()`
+    mod status_tests {
+        use super::*;
+        #[tokio::test]
+        async fn test_network_is_up() {
+            let mut server = mockito::Server::new_async().await;
+            let _mock = server.mock("GET", "/test").with_status(200).create(); // Network is up (HTTP 200 OK)
+
+            let result = check_network_status(&*(server.url() + "/test")).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_network_is_down() {
+            // Non-existent url
+            let result =
+                check_network_status("https://nonexistent-domain-that-will-never-exist.xyz").await;
+            assert!(result.is_err());
+
+            // 5xx error
+            let mut server = mockito::Server::new_async().await;
+            let _mock = server.mock("GET", "/test").with_status(500).create(); // Network is up (HTTP 500 Internal Server Error)
+
+            let result = check_network_status(&*(server.url() + "/test")).await;
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn test_store_last_check_time() {
+            let temp_dir = tempfile::TempDir::new().unwrap();
+            let mock_get_config_path =
+                |_config_dir: &str, filename: &str| temp_dir.path().join(filename);
+
+            store_last_check_time(mock_get_config_path);
+            let file_path = temp_dir.path().join(LAST_CHECK_FILE);
+
+            assert!(file_path.exists()); // last check file should exist
+
+            let content = std::fs::read_to_string(&file_path).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+            assert!(parsed.get("last_check").is_some());
+
+            let timestamp = parsed["last_check"].as_str().unwrap();
+            assert!(chrono::DateTime::parse_from_rfc3339(timestamp).is_ok());
+        }
+
+        #[test]
+        fn test_get_last_check_time() {
+            let temp_dir = tempfile::TempDir::new().unwrap();
+            let mock_get_config_path =
+                |_config_dir: &str, filename: &str| temp_dir.path().join(filename);
+
+            store_last_check_time(mock_get_config_path);
+
+            let result = get_last_check_time(mock_get_config_path);
+
+            let last_check_time = Utc::now();
+            let expected_str = time_ago(DateTime::from(last_check_time));
+
+            assert_eq!(result, Some(expected_str));
+        }
+
+        #[test]
+        fn test_time_ago() {
+            let now = Utc::now();
+
+            let result = time_ago(DateTime::from(now - Duration::seconds(30)));
+            assert_eq!(result, "30 seconds ago");
+
+            let result = time_ago(DateTime::from(now - Duration::minutes(5)));
+            assert_eq!(result, "5 minutes ago");
+
+            let result = time_ago(DateTime::from(now - Duration::hours(3)));
+            assert_eq!(result, "3 hours ago");
+
+            let result = time_ago(DateTime::from(now - Duration::days(7)));
+            assert_eq!(result, "7 days ago");
+
+            let result = time_ago(DateTime::from(now - Duration::days(60)));
+            assert_eq!(result, "2 months ago");
+
+            let result = time_ago(DateTime::from(now - Duration::days(400)));
+            assert_eq!(result, "1 years ago");
+        }
+    }
+
+    /// Tests related to `PID` management:
+    /// 1. `get_stored_pid()`
+    /// 2. `store_pid()`
+    mod pid_tests {
+        use super::*;
+        #[test]
+        fn test_get_stored_pid() {
+            let temp_dir = tempfile::TempDir::new().unwrap();
+            let mock_get_config_path =
+                |_config_dir: &str, filename: &str| temp_dir.path().join(filename);
+
+            // write to file
+            let mock_pid = Pid { pid: Some(1234) };
+            let pid_file_path = temp_dir.path().join(PID_FILE);
+            let pid_data = serde_json::to_string(&mock_pid).unwrap();
+            fs::write(pid_file_path, pid_data).unwrap();
+
+            let result = get_stored_pid(mock_get_config_path);
+            assert_eq!(result, Some(1234));
+        }
+
+        #[test]
+        fn test_get_stored_pid_no_pid_file() {
+            let temp_dir = tempfile::TempDir::new().unwrap();
+            let mock_get_config_path =
+                |_config_dir: &str, filename: &str| temp_dir.path().join(filename);
+
+            let result = get_stored_pid(mock_get_config_path);
+
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn test_store_pid() {
+            let temp_dir = tempfile::TempDir::new().unwrap();
+            let mock_get_config_path =
+                |_config_dir: &str, filename: &str| temp_dir.path().join(filename);
+
+            store_pid(Some(1234), mock_get_config_path);
+
+            let pid_file_path = temp_dir.path().join(PID_FILE);
+            assert!(pid_file_path.exists()); // verify file was created
+
+            let content = fs::read_to_string(pid_file_path).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+            assert_eq!(parsed["pid"], 1234);
+        }
+
+        #[test]
+        fn test_store_pid_none() {
+            let temp_dir = tempfile::TempDir::new().unwrap();
+            let mock_get_config_path =
+                |_config_dir: &str, filename: &str| temp_dir.path().join(filename);
+
+            store_pid(None, mock_get_config_path);
+
+            let pid_file_path = temp_dir.path().join(PID_FILE);
+            assert!(pid_file_path.exists()); // verify file was created
+
+            let content = fs::read_to_string(pid_file_path).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+            assert!(parsed["pid"].is_null());
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ fn process_is_running() -> bool {
                 "Process with PID {} is not running. Cleaning up PID store.",
                 stored_pid
             );
-            store_pid(None);
+            store_pid(None, get_config_path);
             false
         }
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -20,7 +20,7 @@ pub struct Course {
 }
 
 // Registering for a course requires the entire test details
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct TestList {
     pub id_cursus: u32,
     pub studentnummer: String,
@@ -38,7 +38,7 @@ pub struct TestList {
     pub toetsen: Vec<Test>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Test {
     pub id_cursus: u32,
     pub id_toets_gelegenheid: u32,


### PR DESCRIPTION
### Changes
- New file: `controller.rs`
  - Moved `run_loop()`, `get_credentials()`, `run_auto_sign_up()` and `handle_request()` from main.rs into controller.rs. 
  - Storing variables like `is_loop`, `is_boot`, `exit_fn`, `manager` and `api` in the struct Controller helps to reduce duplication of passing down these variables from parent function to child function.
  - These variables are now stored as state in the Controller and initialized in main as either `run_controller` or `start_controller` or `change_controller`
- Fixed network status always printing green color
- Added codecov workflow with tarpaulin

No other behavior was changed.

Closes #72 