### PR TITLE
Fixed Windows terminal flashing on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,6 +2889,7 @@ dependencies = [
  "time",
  "tokio",
  "uuid",
+ "windows",
  "winreg",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ mockall = "0.13.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10"
+windows = { version = "0.56.0", features = ["Win32_UI", "Win32_UI_WindowsAndMessaging", "Win32_System_Console"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ async fn main() {
             }
         }
     }
-  
+
     if let Err(e) = run().await {
         error!("{}", e);
         println!("{}", e.to_string().red().bold());

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,25 @@ const LOGO: &str = "logo.png";
 #[allow(clippy::zombie_processes)]
 #[tokio::main]
 async fn main() {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::System::Console::GetConsoleWindow;
+        use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_HIDE};
+
+        let args: Vec<String> = env::args().collect();
+
+        if args.contains(&"--boot".to_string()) {
+            // Hide the console window if --boot is passed
+            unsafe {
+                let console_window: HWND = GetConsoleWindow();
+                if console_window != HWND(0) {
+                    let _ = ShowWindow(console_window, SW_HIDE); // Hide the console window
+                }
+            }
+        }
+    }
+
     // Check if it's the first setup
     if is_first_setup(dirs::home_dir) {
         display_logo();


### PR DESCRIPTION
Attempts to close the terminal on windows as fast as possible if `--boot` flag is set.